### PR TITLE
--logx support

### DIFF
--- a/fastcodeTemplate.py
+++ b/fastcodeTemplate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 '''
 Created on 25.02.2015
-Modified on 05.03.2015
+Last Modified on 10.03.2015
 
 @author: kevin
 '''

--- a/sampledata.eps
+++ b/sampledata.eps
@@ -1,12 +1,12 @@
 %!PS-Adobe-3.0 EPSF-3.0
 %%Title: sampledata.eps
 %%Creator: matplotlib version 1.4.2, http://matplotlib.org/
-%%CreationDate: Thu Mar  5 06:46:08 2015
+%%CreationDate: Tue Mar 10 23:03:42 2015
 %%Orientation: portrait
 %%BoundingBox: 18 180 594 612
 %%EndComments
 %%BeginProlog
-/mpldict 8 dict def
+/mpldict 9 dict def
 mpldict begin
 /m { moveto } bind def
 /l { lineto } bind def
@@ -26,6 +26,248 @@ clip
 newpath
 } bind def
 %!PS-Adobe-3.0 Resource-Font
+%%Title: DejaVu Sans Condensed Bold
+%%Copyright: Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Copyright (c) 2006 by Tavmjong Bah. All Rights Reserved. DejaVu changes are in public domain 
+%%Creator: Converted from TrueType to type 3 by PPR
+25 dict begin
+/_d{bind def}bind def
+/_m{moveto}_d
+/_l{lineto}_d
+/_cl{closepath eofill}_d
+/_c{curveto}_d
+/_sc{7 -1 roll{setcachedevice}{pop pop pop pop pop pop}ifelse}_d
+/_e{exec}_d
+/FontName /DejaVuSansCondensed-Bold def
+/PaintType 0 def
+/FontMatrix[.001 0 0 .001 0 0]def
+/FontBBox[-962 -415 1778 1174]def
+/FontType 3 def
+/Encoding [ /a /d /e /l /m /p /s /t ] def
+/FontInfo 10 dict dup begin
+/FamilyName (DejaVu Sans Condensed) def
+/FullName (DejaVu Sans Condensed Bold) def
+/Notice (Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Copyright (c) 2006 by Tavmjong Bah. All Rights Reserved. DejaVu changes are in public domain ) def
+/Weight (Bold) def
+/Version (Version 2.34) def
+/ItalicAngle 0.0 def
+/isFixedPitch false def
+/UnderlinePosition -130 def
+/UnderlineThickness 90 def
+end readonly def
+/CharStrings 8 dict dup begin
+/a{{607 0 39 -13 537 560 _sc
+296 246 _m
+263 246 238 239 222 227 _c
+205 215 197 197 197 173 _c
+197 151 203 133 217 121 _c
+230 108 249 102 273 102 _c
+302 102 327 113 347 137 _c
+367 161 378 190 378 226 _c
+378 246 _l
+296 246 _l
+537 312 _m
+537 0 _l
+378 0 _l
+378 81 _l
+356 47 332 23 306 9 _c
+280 -5 248 -13 210 -13 _c
+159 -13 118 3 86 36 _c
+54 68 39 111 39 164 _c
+}_e{39 228 58 275 98 305 _c
+138 335 200 350 285 350 _c
+378 350 _l
+378 364 _l
+378 391 368 411 348 424 _c
+328 437 298 444 257 444 _c
+223 444 191 440 162 432 _c
+133 424 106 413 82 399 _c
+82 532 _l
+115 541 149 548 183 553 _c
+217 557 251 560 285 560 _c
+373 560 437 540 477 501 _c
+517 462 537 399 537 312 _c
+_cl}_e}_d
+/d{{644 0 40 -13 569 760 _sc
+411 467 _m
+411 760 _l
+569 760 _l
+569 0 _l
+411 0 _l
+411 79 _l
+389 47 365 23 339 9 _c
+313 -5 282 -13 248 -13 _c
+187 -13 137 13 99 66 _c
+60 119 41 188 41 273 _c
+41 357 60 425 99 479 _c
+137 533 187 560 248 560 _c
+282 560 312 552 338 537 _c
+364 522 389 499 411 467 _c
+307 113 _m
+340 113 366 126 384 154 _c
+402 181 411 221 411 273 _c
+}_e{411 325 402 364 384 392 _c
+366 419 340 433 307 433 _c
+273 433 248 419 230 392 _c
+212 364 204 325 204 273 _c
+204 221 212 181 230 154 _c
+248 126 273 113 307 113 _c
+_cl}_e}_d
+/e{{610 0 39 -13 567 560 _sc
+567 275 _m
+567 225 _l
+199 225 _l
+203 184 216 153 239 133 _c
+261 112 293 102 335 102 _c
+368 102 402 107 437 118 _c
+471 129 507 146 543 168 _c
+543 33 _l
+506 17 469 6 432 -1 _c
+394 -9 357 -13 320 -13 _c
+231 -13 162 12 113 62 _c
+63 112 39 182 39 273 _c
+39 362 63 432 111 483 _c
+159 534 226 560 312 560 _c
+389 560 451 534 497 482 _c
+}_e{543 430 567 361 567 275 _c
+405 333 _m
+405 366 396 393 379 413 _c
+361 433 339 444 311 444 _c
+280 444 255 434 236 415 _c
+217 396 205 369 201 333 _c
+405 333 _l
+_cl}_e}_d
+/l{308 0 75 0 233 760 _sc
+76 760 _m
+233 760 _l
+233 0 _l
+76 0 _l
+76 760 _l
+_cl}_d
+/m{{938 0 75 0 867 560 _sc
+532 456 _m
+552 490 575 515 603 533 _c
+630 551 660 560 693 560 _c
+749 560 792 540 822 502 _c
+852 463 867 407 867 333 _c
+867 0 _l
+708 0 _l
+708 285 _l
+708 289 709 294 709 298 _c
+709 302 709 309 709 318 _c
+709 356 704 384 694 402 _c
+684 419 667 428 644 428 _c
+614 428 591 414 575 387 _c
+559 359 550 320 550 269 _c
+550 0 _l
+392 0 _l
+392 285 _l
+}_e{392 345 387 384 377 402 _c
+367 419 351 428 327 428 _c
+297 428 273 414 257 387 _c
+241 359 233 320 233 269 _c
+233 0 _l
+75 0 _l
+75 547 _l
+233 547 _l
+233 467 _l
+252 497 274 520 299 536 _c
+324 552 352 560 382 560 _c
+416 560 446 550 472 532 _c
+498 514 518 488 532 456 _c
+_cl}_e}_d
+/p{{644 0 75 -207 604 560 _sc
+233 79 _m
+233 -207 _l
+76 -207 _l
+76 547 _l
+233 547 _l
+233 467 _l
+255 499 279 522 305 537 _c
+331 552 362 560 396 560 _c
+456 560 506 533 545 479 _c
+584 425 604 357 604 273 _c
+604 188 584 119 545 66 _c
+506 13 456 -13 396 -13 _c
+362 -13 331 -5 305 9 _c
+279 23 255 47 233 79 _c
+337 433 _m
+303 433 278 419 260 392 _c
+242 364 233 325 233 273 _c
+}_e{233 221 242 181 260 154 _c
+278 126 303 113 337 113 _c
+371 113 396 126 414 154 _c
+432 181 441 221 441 273 _c
+441 325 432 364 414 392 _c
+396 419 371 433 337 433 _c
+_cl}_e}_d
+/s{{536 0 46 -13 493 560 _sc
+460 530 _m
+460 397 _l
+426 412 394 424 362 432 _c
+330 440 301 444 274 444 _c
+244 444 221 439 207 431 _c
+193 423 186 410 186 393 _c
+186 379 191 368 202 361 _c
+212 353 232 348 261 344 _c
+289 340 _l
+369 328 423 310 451 284 _c
+479 258 493 217 493 161 _c
+493 103 473 59 435 30 _c
+396 1 338 -13 262 -13 _c
+229 -13 195 -10 161 -5 _c
+}_e{126 0 90 8 54 20 _c
+54 153 _l
+85 135 117 122 150 114 _c
+183 106 217 102 251 102 _c
+281 102 304 106 320 116 _c
+336 125 344 139 344 158 _c
+344 174 338 185 328 193 _c
+317 201 296 207 264 211 _c
+236 215 _l
+166 224 116 242 88 269 _c
+60 295 46 335 46 389 _c
+46 447 64 490 100 518 _c
+136 546 191 560 265 560 _c
+293 560 324 557 356 552 _c
+388 547 422 540 460 530 _c
+}_e{_cl}_e}_d
+/t{430 0 12 0 410 702 _sc
+248 702 _m
+248 547 _l
+410 547 _l
+410 422 _l
+248 422 _l
+248 190 _l
+248 164 252 147 261 138 _c
+269 129 287 125 315 125 _c
+396 125 _l
+396 0 _l
+261 0 _l
+199 0 155 14 129 43 _c
+103 71 90 120 90 190 _c
+90 422 _l
+12 422 _l
+12 547 _l
+90 547 _l
+90 702 _l
+248 702 _l
+_cl}_d
+end readonly def
+
+/BuildGlyph
+ {exch begin
+ CharStrings exch
+ 2 copy known not{pop /.notdef}if
+ true 3 1 roll get exec
+ end}_d
+
+/BuildChar {
+ 1 index /Encoding get exch get
+ 1 index /BuildGlyph get exec
+}_d
+
+FontName currentdict end definefont pop
+%!PS-Adobe-3.0 Resource-Font
 %%Title: DejaVu Sans
 %%Copyright: Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Copyright (c) 2006 by Tavmjong Bah. All Rights Reserved. DejaVu changes are in public domain 
 %%Creator: Converted from TrueType to type 3 by PPR
@@ -42,7 +284,7 @@ newpath
 /FontMatrix[.001 0 0 .001 0 0]def
 /FontBBox[-1021 -415 1681 1167]def
 /FontType 3 def
-/Encoding [ /space /slash /zero /one /two /three /four /five /six /seven /eight /E /G /I /K /L /M /S /bracketleft /bracketright /a /c /d /e /f /i /l /m /n /o /p /r /s /t /v /z ] def
+/Encoding [ /space /slash /zero /one /two /three /four /five /six /seven /eight /E /G /I /K /L /M /S /bracketleft /bracketright /a /c /d /e /f /i /l /n /o /p /r /s /t /v /z ] def
 /FontInfo 10 dict dup begin
 /FamilyName (DejaVu Sans) def
 /FullName (DejaVu Sans) def
@@ -54,7 +296,7 @@ newpath
 /UnderlinePosition -130 def
 /UnderlineThickness 90 def
 end readonly def
-/CharStrings 36 dict dup begin
+/CharStrings 35 dict dup begin
 /space{318 0 0 0 0 0 _sc
 }_d
 /slash{337 0 0 -92 337 729 _sc
@@ -554,36 +796,6 @@ _cl}_d
 94 0 _l
 94 760 _l
 _cl}_d
-/m{{974 0 91 0 889 560 _sc
-520 442 _m
-542 482 569 511 600 531 _c
-631 550 668 560 711 560 _c
-767 560 811 540 842 500 _c
-873 460 889 403 889 330 _c
-889 0 _l
-799 0 _l
-799 327 _l
-799 379 789 418 771 444 _c
-752 469 724 482 686 482 _c
-639 482 602 466 575 435 _c
-548 404 535 362 535 309 _c
-535 0 _l
-445 0 _l
-445 327 _l
-445 379 435 418 417 444 _c
-398 469 369 482 331 482 _c
-}_e{285 482 248 466 221 435 _c
-194 404 181 362 181 309 _c
-181 0 _l
-91 0 _l
-91 547 _l
-181 547 _l
-181 462 _l
-201 495 226 520 255 536 _c
-283 552 317 560 357 560 _c
-397 560 430 550 458 530 _c
-486 510 506 480 520 442 _c
-_cl}_e}_d
 /n{634 0 91 0 549 560 _sc
 549 330 _m
 549 0 _l
@@ -770,10 +982,10 @@ cl
 fill
 grestore
 gsave
-28.8 43.2 m
-547.2 43.2 l
-547.2 384.48 l
-28.8 384.48 l
+40.32 43.2 m
+552.96 43.2 l
+552.96 384.48 l
+40.32 384.48 l
 cl
 0.941 setgray
 fill
@@ -800,13 +1012,13 @@ grestore
 stroke
 grestore
 } bind def
-38.7692 43.2 o
+50.1785 43.2 o
 grestore
 /DejaVuSans findfont
 12.000 scalefont
 setfont
 gsave
-35.581731 26.075000 translate
+46.990962 26.075000 translate
 0.000000 rotate
 0.000000 0.000000 m /four glyphshow
 grestore
@@ -827,10 +1039,10 @@ grestore
 stroke
 grestore
 } bind def
-138.462 43.2 o
+148.763 43.2 o
 grestore
 gsave
-135.445913 26.075000 translate
+145.747452 26.075000 translate
 0.000000 rotate
 0.000000 0.000000 m /six glyphshow
 grestore
@@ -851,10 +1063,10 @@ grestore
 stroke
 grestore
 } bind def
-238.154 43.2 o
+247.348 43.2 o
 grestore
 gsave
-235.153846 26.075000 translate
+244.347692 26.075000 translate
 0.000000 rotate
 0.000000 0.000000 m /eight glyphshow
 grestore
@@ -875,10 +1087,10 @@ grestore
 stroke
 grestore
 } bind def
-337.846 43.2 o
+345.932 43.2 o
 grestore
 gsave
-331.260216 26.075000 translate
+339.346370 26.075000 translate
 0.000000 rotate
 0.000000 0.000000 m /one glyphshow
 7.634766 0.000000 m /zero glyphshow
@@ -900,10 +1112,10 @@ grestore
 stroke
 grestore
 } bind def
-437.538 43.2 o
+444.517 43.2 o
 grestore
 gsave
-431.155649 26.075000 translate
+438.134111 26.075000 translate
 0.000000 rotate
 0.000000 0.000000 m /one glyphshow
 7.634766 0.000000 m /two glyphshow
@@ -925,16 +1137,16 @@ grestore
 stroke
 grestore
 } bind def
-537.231 43.2 o
+543.102 43.2 o
 grestore
 gsave
-530.582332 26.075000 translate
+536.453101 26.075000 translate
 0.000000 rotate
 0.000000 0.000000 m /one glyphshow
 7.634766 0.000000 m /four glyphshow
 grestore
 gsave
-285.250000 9.450000 translate
+293.890000 9.450000 translate
 0.000000 rotate
 0.000000 0.000000 m /n glyphshow
 grestore
@@ -942,144 +1154,147 @@ grestore
 2 setlinecap
 1.000 setgray
 gsave
-518.4 341.3 28.8 43.2 clipbox
-28.8 43.2 m
-547.2 43.2 l
+512.6 341.3 40.32 43.2 clipbox
+40.32 56.4314 m
+552.96 56.4314 l
 stroke
 grestore
 0.000 setgray
 gsave
-18.753125 39.887500 translate
+30.273125 53.118944 translate
 0.000000 rotate
 0.000000 0.000000 m /zero glyphshow
 grestore
 1.000 setgray
 gsave
-518.4 341.3 28.8 43.2 clipbox
-28.8 91.9543 m
-547.2 91.9543 l
+512.6 341.3 40.32 43.2 clipbox
+40.32 102.057 m
+552.96 102.057 l
 stroke
 grestore
 0.000 setgray
 gsave
-19.581250 88.641786 translate
+31.101250 98.744612 translate
 0.000000 rotate
 0.000000 0.000000 m /one glyphshow
 grestore
 1.000 setgray
 gsave
-518.4 341.3 28.8 43.2 clipbox
-28.8 140.709 m
-547.2 140.709 l
+512.6 341.3 40.32 43.2 clipbox
+40.32 147.683 m
+552.96 147.683 l
 stroke
 grestore
 0.000 setgray
 gsave
-19.237500 137.396071 translate
+30.757500 144.370281 translate
 0.000000 rotate
 0.000000 0.000000 m /two glyphshow
 grestore
 1.000 setgray
 gsave
-518.4 341.3 28.8 43.2 clipbox
-28.8 189.463 m
-547.2 189.463 l
+512.6 341.3 40.32 43.2 clipbox
+40.32 193.308 m
+552.96 193.308 l
 stroke
 grestore
 0.000 setgray
 gsave
-19.050000 186.150357 translate
+30.570000 189.995949 translate
 0.000000 rotate
 0.000000 0.000000 m /three glyphshow
 grestore
 1.000 setgray
 gsave
-518.4 341.3 28.8 43.2 clipbox
-28.8 238.217 m
-547.2 238.217 l
+512.6 341.3 40.32 43.2 clipbox
+40.32 238.934 m
+552.96 238.934 l
 stroke
 grestore
 0.000 setgray
 gsave
-18.425000 234.904643 translate
+29.945000 235.621618 translate
 0.000000 rotate
 0.000000 0.000000 m /four glyphshow
 grestore
 1.000 setgray
 gsave
-518.4 341.3 28.8 43.2 clipbox
-28.8 286.971 m
-547.2 286.971 l
+512.6 341.3 40.32 43.2 clipbox
+40.32 284.56 m
+552.96 284.56 l
 stroke
 grestore
 0.000 setgray
 gsave
-19.128125 283.658929 translate
+30.648125 281.247286 translate
 0.000000 rotate
 0.000000 0.000000 m /five glyphshow
 grestore
 1.000 setgray
 gsave
-518.4 341.3 28.8 43.2 clipbox
-28.8 335.726 m
-547.2 335.726 l
+512.6 341.3 40.32 43.2 clipbox
+40.32 330.185 m
+552.96 330.185 l
 stroke
 grestore
 0.000 setgray
 gsave
-18.768750 332.413214 translate
+30.288750 326.872955 translate
 0.000000 rotate
 0.000000 0.000000 m /six glyphshow
 grestore
 1.000 setgray
 gsave
-518.4 341.3 28.8 43.2 clipbox
-28.8 384.48 m
-547.2 384.48 l
+512.6 341.3 40.32 43.2 clipbox
+40.32 375.811 m
+552.96 375.811 l
 stroke
 grestore
 0.000 setgray
 gsave
-19.175000 381.167500 translate
+30.695000 372.498623 translate
 0.000000 rotate
 0.000000 0.000000 m /seven glyphshow
 grestore
 0.333 setgray
+/DejaVuSans findfont
+9.996 scalefont
+setfont
 gsave
-33.984000 390.392800 translate
+71.078400 389.970925 translate
 0.000000 rotate
 0.000000 0.000000 m /bracketleft glyphshow
-4.681641 0.000000 m /G glyphshow
-13.980469 0.000000 m /f glyphshow
-18.205078 0.000000 m /l glyphshow
-21.539062 0.000000 m /o glyphshow
-28.880859 0.000000 m /p glyphshow
-36.498047 0.000000 m /space glyphshow
-40.312500 0.000000 m /slash glyphshow
-44.355469 0.000000 m /space glyphshow
-48.169922 0.000000 m /s glyphshow
-54.421875 0.000000 m /bracketright glyphshow
+3.901367 0.000000 m /G glyphshow
+11.650391 0.000000 m /f glyphshow
+15.170898 0.000000 m /l glyphshow
+17.949219 0.000000 m /o glyphshow
+24.067383 0.000000 m /p glyphshow
+30.415039 0.000000 m /space glyphshow
+33.593750 0.000000 m /slash glyphshow
+36.962891 0.000000 m /space glyphshow
+40.141602 0.000000 m /s glyphshow
+45.351562 0.000000 m /bracketright glyphshow
 grestore
 1.000 0.502 0.502 setrgbcolor
 gsave
-518.4 341.3 28.8 43.2 clipbox
-38.7692 243.093 m
-88.6154 282.096 l
-138.462 325.975 l
-188.308 345.477 l
-238.154 340.601 l
-288 321.099 l
-337.846 316.224 l
-387.692 306.473 l
-437.538 306.473 l
-487.385 296.722 l
-537.231 296.722 l
+512.6 341.3 40.32 43.2 clipbox
+50.1785 243.497 m
+99.4708 279.997 l
+148.763 321.06 l
+198.055 339.311 l
+247.348 334.748 l
+296.64 316.498 l
+345.932 311.935 l
+395.225 302.81 l
+444.517 302.81 l
+493.809 293.685 l
+543.102 293.685 l
 stroke
 grestore
 0.500 setlinewidth
 0 setlinecap
 gsave
-518.4 341.3 28.8 43.2 clipbox
+512.6 341.3 40.32 43.2 clipbox
 /o {
 gsave
 newpath
@@ -1104,40 +1319,40 @@ grestore
 stroke
 grestore
 } bind def
-38.7692 243.093 o
-88.6154 282.096 o
-138.462 325.975 o
-188.308 345.477 o
-238.154 340.601 o
-288 321.099 o
-337.846 316.224 o
-387.692 306.473 o
-437.538 306.473 o
-487.385 296.722 o
-537.231 296.722 o
+50.1785 243.497 o
+99.4708 279.997 o
+148.763 321.06 o
+198.055 339.311 o
+247.348 334.748 o
+296.64 316.498 o
+345.932 311.935 o
+395.225 302.81 o
+444.517 302.81 o
+493.809 293.685 o
+543.102 293.685 o
 grestore
 2.000 setlinewidth
 2 setlinecap
 0.502 0.502 1.000 setrgbcolor
 gsave
-518.4 341.3 28.8 43.2 clipbox
-38.7692 130.958 m
-88.6154 174.837 l
-138.462 189.463 l
-188.308 199.214 l
-238.154 169.961 l
-288 174.837 l
-337.846 179.712 l
-387.692 145.584 l
-437.538 165.086 l
-487.385 165.086 l
-537.231 160.21 l
+512.6 341.3 40.32 43.2 clipbox
+50.1785 138.558 m
+99.4708 179.621 l
+148.763 193.308 l
+198.055 202.434 l
+247.348 175.058 l
+296.64 179.621 l
+345.932 184.183 l
+395.225 152.245 l
+444.517 170.496 l
+493.809 170.496 l
+543.102 165.933 l
 stroke
 grestore
 0.500 setlinewidth
 0 setlinecap
 gsave
-518.4 341.3 28.8 43.2 clipbox
+512.6 341.3 40.32 43.2 clipbox
 /o {
 gsave
 newpath
@@ -1162,40 +1377,40 @@ grestore
 stroke
 grestore
 } bind def
-38.7692 130.958 o
-88.6154 174.837 o
-138.462 189.463 o
-188.308 199.214 o
-238.154 169.961 o
-288 174.837 o
-337.846 179.712 o
-387.692 145.584 o
-437.538 165.086 o
-487.385 165.086 o
-537.231 160.21 o
+50.1785 138.558 o
+99.4708 179.621 o
+148.763 193.308 o
+198.055 202.434 o
+247.348 175.058 o
+296.64 179.621 o
+345.932 184.183 o
+395.225 152.245 o
+444.517 170.496 o
+493.809 170.496 o
+543.102 165.933 o
 grestore
 2.000 setlinewidth
 2 setlinecap
 0.251 0.502 0.251 setrgbcolor
 gsave
-518.4 341.3 28.8 43.2 clipbox
-38.7692 130.958 m
-88.6154 140.709 l
-138.462 135.833 l
-188.308 140.709 l
-238.154 135.833 l
-288 135.833 l
-337.846 135.833 l
-387.692 130.958 l
-437.538 130.958 l
-487.385 135.833 l
-537.231 135.833 l
+512.6 341.3 40.32 43.2 clipbox
+50.1785 138.558 m
+99.4708 147.683 l
+148.763 143.12 l
+198.055 147.683 l
+247.348 143.12 l
+296.64 143.12 l
+345.932 143.12 l
+395.225 138.558 l
+444.517 138.558 l
+493.809 143.12 l
+543.102 143.12 l
 stroke
 grestore
 0.500 setlinewidth
 0 setlinecap
 gsave
-518.4 341.3 28.8 43.2 clipbox
+512.6 341.3 40.32 43.2 clipbox
 /o {
 gsave
 newpath
@@ -1220,40 +1435,40 @@ grestore
 stroke
 grestore
 } bind def
-38.7692 130.958 o
-88.6154 140.709 o
-138.462 135.833 o
-188.308 140.709 o
-238.154 135.833 o
-288 135.833 o
-337.846 135.833 o
-387.692 130.958 o
-437.538 130.958 o
-487.385 135.833 o
-537.231 135.833 o
+50.1785 138.558 o
+99.4708 147.683 o
+148.763 143.12 o
+198.055 147.683 o
+247.348 143.12 o
+296.64 143.12 o
+345.932 143.12 o
+395.225 138.558 o
+444.517 138.558 o
+493.809 143.12 o
+543.102 143.12 o
 grestore
 2.000 setlinewidth
 2 setlinecap
 1.000 0.502 1.000 setrgbcolor
 gsave
-518.4 341.3 28.8 43.2 clipbox
-38.7692 77.328 m
-88.6154 101.705 l
-138.462 140.709 l
-188.308 189.463 l
-238.154 243.093 l
-288 291.847 l
-337.846 316.224 l
-387.692 306.473 l
-437.538 243.093 l
-487.385 243.093 l
-537.231 228.466 l
+512.6 341.3 40.32 43.2 clipbox
+50.1785 88.3694 m
+99.4708 111.182 l
+148.763 147.683 l
+198.055 193.308 l
+247.348 243.497 l
+296.64 289.122 l
+345.932 311.935 l
+395.225 302.81 l
+444.517 243.497 l
+493.809 243.497 l
+543.102 229.809 l
 stroke
 grestore
 0.500 setlinewidth
 0 setlinecap
 gsave
-518.4 341.3 28.8 43.2 clipbox
+512.6 341.3 40.32 43.2 clipbox
 /o {
 gsave
 newpath
@@ -1278,30 +1493,33 @@ grestore
 stroke
 grestore
 } bind def
-38.7692 77.328 o
-88.6154 101.705 o
-138.462 140.709 o
-188.308 189.463 o
-238.154 243.093 o
-288 291.847 o
-337.846 316.224 o
-387.692 306.473 o
-437.538 243.093 o
-487.385 243.093 o
-537.231 228.466 o
+50.1785 88.3694 o
+99.4708 111.182 o
+148.763 147.683 o
+198.055 193.308 o
+247.348 243.497 o
+296.64 289.122 o
+345.932 311.935 o
+395.225 302.81 o
+444.517 243.497 o
+493.809 243.497 o
+543.102 229.809 o
 grestore
 1.000 setlinewidth
 0 setlinejoin
 2 setlinecap
 0.000 setgray
 gsave
-28.8 43.2 m
-547.2 43.2 l
+40.32 43.2 m
+552.96 43.2 l
 stroke
 grestore
 1.000 0.502 0.502 setrgbcolor
+/DejaVuSans findfont
+12.000 scalefont
+setfont
 gsave
-87.887910 343.175072 translate
+91.658728 334.811821 translate
 0.000000 rotate
 0.000000 0.000000 m /S glyphshow
 7.617188 0.000000 m /p glyphshow
@@ -1316,7 +1534,7 @@ gsave
 grestore
 0.502 0.502 1.000 setrgbcolor
 gsave
-70.876740 203.953671 translate
+74.992256 207.059949 translate
 0.000000 rotate
 0.000000 0.000000 m /S glyphshow
 7.617188 0.000000 m /p glyphshow
@@ -1338,7 +1556,7 @@ gsave
 grestore
 0.251 0.502 0.251 setrgbcolor
 gsave
-411.693510 116.382974 translate
+424.025817 118.181147 translate
 0.000000 rotate
 0.000000 0.000000 m /S glyphshow
 7.617188 0.000000 m /p glyphshow
@@ -1356,7 +1574,7 @@ gsave
 grestore
 1.000 0.502 1.000 setrgbcolor
 gsave
-184.128791 266.029794 translate
+186.062036 257.248184 translate
 0.000000 rotate
 0.000000 0.000000 m /I glyphshow
 3.539062 0.000000 m /n glyphshow
@@ -1369,22 +1587,22 @@ gsave
 48.603516 0.000000 m /L glyphshow
 grestore
 0.000 setgray
-/DejaVuSans findfont
-17.280 scalefont
+/DejaVuSansCondensed-Bold findfont
+14.400 scalefont
 setfont
 gsave
-33.984000 406.662450 translate
+71.078400 402.624650 translate
 0.000000 rotate
 0.000000 0.000000 m /s glyphshow
-8.987183 0.000000 m /a glyphshow
-19.557861 0.000000 m /m glyphshow
-36.361450 0.000000 m /p glyphshow
-47.311157 0.000000 m /l glyphshow
-52.103760 0.000000 m /e glyphshow
-62.716553 0.000000 m /d glyphshow
-73.666260 0.000000 m /a glyphshow
-84.236938 0.000000 m /t glyphshow
-91.000488 0.000000 m /a glyphshow
+7.699890 0.000000 m /a glyphshow
+16.424561 0.000000 m /m glyphshow
+29.901123 0.000000 m /p glyphshow
+39.159241 0.000000 m /l glyphshow
+43.588257 0.000000 m /e glyphshow
+52.362061 0.000000 m /d glyphshow
+61.620178 0.000000 m /a glyphshow
+70.344849 0.000000 m /t glyphshow
+76.528625 0.000000 m /a glyphshow
 grestore
 
 end


### PR DESCRIPTION
Add --logx or -l flag which makes x-axis log-scale.

Make automatic labelling better.
- Now uses a sorted list of scores per data point instead of random sampling.
- Also normalizes data first to ensure proportions don't affect labelling algorithm.
